### PR TITLE
fix binding error for do_require errors

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1957,7 +1957,9 @@ const errors_to_decl = (ci: ContractInterface): ts.PropertyDeclaration => {
     undefined,
     factory.createObjectLiteralExpression(
       ci.errors.map(make_error).reduce((acc, x) => {
-        const [label, expr] = x
+        const regex = /['`]/g
+        let [label, expr] = x;
+        label = label.replace(regex, "")
         if (!acc.reduce((a, p) => {
           const [l, _] = p
           if (!a) {


### PR DESCRIPTION
There is a bug where if a single quote or backtick is included in the error message for a do_require statement, the error message itself used as the label. This inserts the single quote or backtick into the js code of the binding file. Example from generated binding file (Note single quote in the first line) :

```
errors = {
        THE_FEES_DON'T_ADD_UP: att.string_to_mich("\"The fees don't add up\""),
        OPTION_IS_NONE: att.string_to_mich("\"OPTION_IS_NONE\""),
        r_auctionOngoing: att.string_to_mich("\"The auction has already concluded\""), 
INVALID_CALLER: att.string_to_mich("\"INVALID_CALLER\"")
    };
```

Making this change in my local node modules folder fixed the bug for me, but I wasn't able to figure out how to get the tests working in this repo, so I haven't run your tests. 